### PR TITLE
fix: use python3 instead of python in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -71,7 +71,7 @@ echo "🔧 Setting up shell integration..."
 if ! grep -q "k8r()" "$SHELL_RC" 2>/dev/null; then
     echo "" >> "$SHELL_RC"
     echo "# k8s-run (k8r) - Added by installer" >> "$SHELL_RC"
-    python k8r.py env >> "$SHELL_RC"
+    python3 k8r.py env >> "$SHELL_RC"
     echo "✅ Shell integration added to $SHELL_RC"
 else
     echo "ℹ️  Shell integration already exists in $SHELL_RC"


### PR DESCRIPTION
## Summary
- Fixed install script to use `python3` instead of `python` command
- Resolves installation failures on systems that don't have `python` command (macOS, Ubuntu 20.04+)

## Problem
The install script was using `python k8r.py env` which fails on many modern systems that only provide `python3`. This caused the shell integration setup to fail during installation.

## Solution
Changed line 74 to use `python3 k8r.py env` which is consistent with the prerequisites check that already requires `python3`.

## Test plan
- [x] Verified the fix resolves the installation error
- [x] Install script already checks for `python3` in prerequisites
- [x] Change is minimal and safe

🤖 Generated with [Claude Code](https://claude.ai/code)